### PR TITLE
@order tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ gulp.task('default', ['help']);
  * description.
  *
  * @task {demo}
+ * @order {1}
  */
  gulp.task('demo', function() {});
 
@@ -119,6 +120,11 @@ Task description could be written in a free form before the `@task` tag
 declaration.
 
 If `@task` tag is omitted then the task will not appear in usage call.
+
+Optionally, you can use the `@order` tag to sort the tasks descriptions
+in the output. A task with `@order {1}` will appear before a task
+with `@order {2}`. All tasks without this tag will appear at the end
+of the list, sorted alphabetically.
 
 ## Restrictions
 


### PR DESCRIPTION
One can now specify order of descriptions regardless of alphabetical order of the task names, e.g. `@order {1}`, `@order {10}`.

When there is no `@order`, the plugin behaves as previously - prints the tasks in alphabetical order.

Now, you can display how to build the app first, then how to lint it, test it and finally, deploy :-)
