### PR TITLE
Ability to hide dependencies in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Options are:
   * **padding** - number of empty characters for left-padding of the output
   * **logger** - printing engine (by default is console). May be changed
     to gulp-util or some other printing device if required.
+  * **displayDependencies** - if set to `true` (default), prints the task
+    dependencies below its help description
 
 Example of custom configuration: 
 

--- a/index.js
+++ b/index.js
@@ -249,12 +249,12 @@ function print() {
             }
         });
 
-        if (OPTIONS.displayDependencies) {
-            (deps.length) && (OPTIONS.logger.log(
+        if (OPTIONS.displayDependencies && deps.length) {
+            OPTIONS.logger.log(
                 ' '.repeat(OPTIONS.keysColumnWidth) +
                 chalk.bold.gray('Depends: ') +
                 chalk.grey(JSON.stringify(deps))
-            ));
+            );
         }
 
         OPTIONS.logger.log('');

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ var OPTIONS = {
     keysColumnWidth: 20,
     padding: 4,
     logger: console,
-    isTypescript: fs.existsSync('gulpfile.ts')
+    isTypescript: fs.existsSync('gulpfile.ts'),
+    displayDependencies: true
 };
 
 function rdeps(nodes) {
@@ -248,11 +249,13 @@ function print() {
             }
         });
 
-        (deps.length) && (OPTIONS.logger.log(
-            ' '.repeat(OPTIONS.keysColumnWidth) +
-            chalk.bold.gray('Depends: ') +
-            chalk.grey(JSON.stringify(deps))
-        ));
+        if (OPTIONS.displayDependencies) {
+            (deps.length) && (OPTIONS.logger.log(
+                ' '.repeat(OPTIONS.keysColumnWidth) +
+                chalk.bold.gray('Depends: ') +
+                chalk.grey(JSON.stringify(deps))
+            ));
+        }
 
         OPTIONS.logger.log('');
     });


### PR DESCRIPTION
One can now set the `displayDependencies: false` option in order not to show task dependencies in the output.
