### PR TITLE
Ability to hide empty line between tasks in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Options are:
   * **padding** - number of empty characters for left-padding of the output
   * **logger** - printing engine (by default is console). May be changed
     to gulp-util or some other printing device if required.
+  * **emptyLineBetweenTasks** - if set to `true` (default), prints an empty
+    line between tasks help descriptions
 
 Example of custom configuration: 
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ var OPTIONS = {
     keysColumnWidth: 20,
     padding: 4,
     logger: console,
-    isTypescript: fs.existsSync('gulpfile.ts')
+    isTypescript: fs.existsSync('gulpfile.ts'),
+    emptyLineBetweenTasks: true
 };
 
 function rdeps(nodes) {
@@ -254,7 +255,9 @@ function print() {
             chalk.grey(JSON.stringify(deps))
         ));
 
-        OPTIONS.logger.log('');
+        if (OPTIONS.emptyLineBetweenTasks) {
+            OPTIONS.logger.log('');
+        }
     });
 }
 


### PR DESCRIPTION
One can now set the `emptyLineBetweenTasks: false` option in order not to show empty line between tasks descriptions in the output.
