### PR TITLE
NoDocCrashFix: Fix for a crash when not tasks have been documented.

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function build(gulp) {
     var localRxArgs = new RegExp(rxArgs);
     var globalRxOrder = new RegExp(rxOrder, 'g');
     var localRxOrder = new RegExp(rxOrder);
-    var jsDoc  = source.match(globalRxDoc);
+    var jsDoc  = (source.match(globalRxDoc) || []);
     var tasks = gulpTasks(gulp);
 
     Object.keys(tasks).forEach(function (task) {


### PR DESCRIPTION
`source.match()` returns null on no match.

Fix provides an empty array instead, which prevents the crash.

Since only developers would run into this problem, it might make sense to setup a fake task that instructs the developer on what to do to get started.  That's a philosophical change though, so leaving that decision to the project owner.