### PR TITLE
FixLongArgumentCrash: String.repeat() gets passed a negative number.

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,9 +223,9 @@ function print() {
         var text = ' '.repeat(OPTIONS.padding) +
             chalk.bold.green(task.name) +
             ' '.repeat(
-                OPTIONS.keysColumnWidth -
+                Math.max(1,OPTIONS.keysColumnWidth -
                 OPTIONS.padding -
-                task.name.length
+                task.name.length)
             );
         var chunks = chunk(task.desc, OPTIONS.lineWidth -
             OPTIONS.keysColumnWidth);
@@ -251,8 +251,8 @@ function print() {
             OPTIONS.logger.log(
                 ' '.repeat(OPTIONS.padding + 1) +
                 chalk.bold.cyan('--' + arg.name) +
-                ' '.repeat(OPTIONS.keysColumnWidth - OPTIONS.padding -
-                    arg.name.length - 3) +
+                ' '.repeat(Math.max(1,OPTIONS.keysColumnWidth - OPTIONS.padding -
+                    arg.name.length - 3)) +
                 chunks[i]
             );
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,13 +14,14 @@ if (typeof glob.describe === 'undefined') {
  *
  * @task {demo}
  * @arg {env} environment
+ * @arg {something very long} very long
  */
 gulp.task('demo', function() {});
 
 // testing section
 
 describe('help', function() {
-    it('it should correctly parse task dock-blocks and produce valid output',
+    it('it should correctly parse task doc-blocks and produce valid output',
     function(done) {
         var logger = {
             output: '',


### PR DESCRIPTION
Added Math.max() cal around places where subtraction is used to calculate the repeat amount, assuring a minimum repeat value of 1 for padding around arguments and commands.
Updated test to cause this condition for arguments.