### PR TITLE
Added option to specify full path of gulpfile containing jsDocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Options are:
     dependencies below its help description
   * **emptyLineBetweenTasks** - if set to `true` (default), prints an empty
     line between tasks help descriptions
+  * **gulpfile** - full path to gulpfile containing jsDoc tags.  By default 
+    ignores any files in node_modules.  
 
 Example of custom configuration: 
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ var reflection = {};
  *        log: function
  *     },
  *     isTypescript: boolean,
+ *     gulpfile: string,
  *     displayDependencies: boolean,
  *     emptyLineBetweenTasks: boolean,
  *     defaultGroupName: string
@@ -57,6 +58,7 @@ var OPTIONS = {
     groupColor: 'magenta',
     logger: console,
     isTypescript: fs.existsSync('gulpfile.ts'),
+    gulpfile: undefined,
     displayDependencies: true,
     emptyLineBetweenTasks: true,
     defaultGroupName: 'Common tasks'
@@ -116,6 +118,8 @@ function build(gulp) {
 
     var source = OPTIONS.isTypescript ?
         fs.readFileSync('gulpfile.ts').toString() :
+        OPTIONS.gulpfile ?
+            fs.readFileSync(OPTIONS.gulpfile).toString() :
         Object.keys(require.cache || {'gulpfile.js': ''}).map(function(file) {
             if (!/node_modules|\.json$/.test(file)) {
                 return fs.readFileSync(file).toString() + '\n';


### PR DESCRIPTION
Mykhailo,
We are creating custom gulp tasks in a npm library and wanted to have them documented with gulp-help-doc.   Default search algorithm ignores any files in node_modules.   It will not find a file containing jsDoc tags when packaging custom gulp targets in an npm library.  
Added option to specify full path of gulpfile containing jsDocs to override the default search.

Ralph
